### PR TITLE
Fix: Update session immediately after name change

### DIFF
--- a/app/account/edit/page.tsx
+++ b/app/account/edit/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 
 export default function EditProfilePage() {
-  const { data: session, status } = useSession();
+  const { data: session, status, update } = useSession();
   const router = useRouter();
 
   const [name, setName] = useState("");
@@ -54,6 +54,8 @@ export default function EditProfilePage() {
 
       if (res.ok) {
         setNameMessage("Name updated successfully");
+        // Update the session to reflect the new name immediately
+        await update({ name });
       } else {
         setNameError(data.error || "Failed to update name");
       }

--- a/lib/auth-config.ts
+++ b/lib/auth-config.ts
@@ -59,15 +59,21 @@ export const authOptions: AuthOptions = {
     }),
   ],
   callbacks: {
-    jwt({ token, user }) {
+    jwt({ token, user, trigger, session }) {
       if (user) {
         token.role = (user as any).role;
+        token.name = user.name;
+      }
+      // Handle session updates (e.g., when update() is called)
+      if (trigger === "update" && session) {
+        token.name = session.name;
       }
       return token;
     },
     session({ session, token }) {
       if (session.user) {
         (session.user as any).role = token.role;
+        session.user.name = token.name as string | null | undefined;
       }
       return session;
     },


### PR DESCRIPTION
Previously, when users updated their name in the My Account page, the change would only be visible after signing out and back in. This was because the NextAuth session was not being refreshed after the profile update.

## Changes made:
- Updated NextAuth JWT callback to handle session updates via the trigger parameter
- Updated NextAuth session callback to properly sync the name field from token
- Modified the edit profile page to call update() after successful name change
- The session now refreshes immediately, showing the new name without requiring re-authentication

Fixes #12

Generated with [Claude Code](https://claude.ai/code)